### PR TITLE
fix: :bug: try parse json format

### DIFF
--- a/jobs/upload_qdrant_job.py
+++ b/jobs/upload_qdrant_job.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Optional, Union
 
 from httpx import request
 
@@ -14,42 +14,110 @@ qdrant_service = QdrantService()
 API_URL = API_WEBHOOK + "/api/webhooks/knowledge-base"
 
 
-def upload_qdrant_job(media_id: str, metadata: str, agent_id: int, file: str):
+def _maybe_parse_json_from_bytes(file_bytes: bytes) -> Optional[List[dict]]:
     """
-    Faz upload de documentos para o Qdrant.
-    Suporta arquivos comuns (PDF/DOCX/TXT) e JSON.
+    Tenta decodificar bytes como UTF-8 e carregar JSON.
+    Retorna uma lista de dicts (registros) ou None se não parecer JSON.
+    Aceita formatos:
+      - Lista de objetos: [ {...}, {...} ]
+      - Objeto com lista dentro: { "items": [ ... ] } (ou "data", "products", etc.)
     """
+    try:
+        text = file_bytes.decode("utf-8-sig")  # lida com BOM
+    except UnicodeDecodeError:
+        return None
 
+    s = text.strip()
+    if not s or s[0] not in "[{":
+        return None
+
+    try:
+        data = json.loads(s)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(data, list):
+        # Lista de registros
+        return data
+    if isinstance(data, dict):
+        # Tenta encontrar uma lista em chaves comuns
+        for key in ("items", "data", "products", "records", "result"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return None
+
+
+def _build_content_from_item(item: dict) -> str:
+    """
+    Monta um texto de conteúdo a partir de um item de produto/registro.
+    Tenta campos comuns em PT/EN. Se não achar, cria um resumo dos primeiros pares chave:valor.
+    """
+    name = (
+        item.get("nome")
+        or item.get("titulo")
+        or item.get("name")
+        or item.get("title")
+        or ""
+    )
+    desc = (
+        item.get("descricao")
+        or item.get("descrição")
+        or item.get("description")
+        or item.get("short_description")
+        or item.get("detalhes")
+        or ""
+    )
+
+    if name or desc:
+        content = f"{name} - {desc}".strip(" -")
+        if not content:
+            content = json.dumps(item, ensure_ascii=False)
+        return content
+
+    # fallback: sumariza alguns campos simples
+    pieces = []
+    for k, v in list(item.items())[:8]:
+        if isinstance(v, (str, int, float, bool)) and k not in ("id_interno",):
+            pieces.append(f"{k}: {v}")
+    if pieces:
+        return " | ".join(pieces)
+    return json.dumps(item, ensure_ascii=False)
+
+
+def upload_qdrant_job(media_id: str, metadata: str, agent_id: int, file: bytes):
+    """
+    Ingestão no Qdrant:
+      - Se o conteúdo for JSON válido (bytes → utf-8 → json.loads), cria documentos direto.
+      - Caso contrário, usa o extrator (Docling) para PDF/DOCX/TXT etc.
+    """
     documents: List[DocumentInterface] = []
 
     try:
-        # --- Caso seja JSON ---
-        if file.endswith(".json") or file.endswith(".json.txt"):
-            with open(file, "r", encoding="utf-8") as f:
-                data = json.load(f)
+        # Tenta JSON primeiro (funciona para .json e .txt)
+        json_rows = _maybe_parse_json_from_bytes(file)
 
-            # Garante que seja lista
-            if not isinstance(data, list):
-                raise ValueError("O JSON precisa ser uma lista de objetos")
-
-            for i, item in enumerate(data):
-                # Personalize o conteúdo do chunk
-                content = f"{item.get('nome', '')} - {item.get('descricao', '')}"
-
+        if json_rows is not None:
+            # JSON reconhecido
+            for i, raw in enumerate(json_rows):
+                item = raw if isinstance(raw, dict) else {"value": raw}
+                content = _build_content_from_item(item)
                 documents.append(
                     DocumentInterface(
-                        content=content.strip(),
+                        content=content,
                         metadata=MetadataInterface(
                             index=i,
                             agent_id=agent_id,
                             media_id=media_id,
-                            metadata=item,  # guarda todo o objeto como metadata
+                            # Mantém como string (Pydantic espera str):
+                            metadata=json.dumps(item, ensure_ascii=False),
                         ),
                     )
                 )
 
         # --- Caso comum (usa Docling Extract) ---
         else:
+            # Não era JSON → usa o pipeline Docling normalmente
             extracted_docs: List[str] = extract.run(source=file)
             for i, doc_text in enumerate(extracted_docs):
                 documents.append(
@@ -64,7 +132,7 @@ def upload_qdrant_job(media_id: str, metadata: str, agent_id: int, file: str):
                     )
                 )
 
-        # --- Inserir no Qdrant ---
+        # Inserir no Qdrant
         response = qdrant_service.insert_documents(
             collection_name=QDRANT_COLLECTION, documents=documents
         )


### PR DESCRIPTION
## O que foi feito?

Assinatura da função permanece igual (file: bytes), compatível com o seu start_job.

Não depende do nome do arquivo; detecta JSON pelo conteúdo.

MetadataInterface.metadata continua string — usamos json.dumps(item, ensure_ascii=False).

Se o `JSON` não for uma lista, também aceitamos estruturas como `{"items": [...]}` ou `{"data": [...]}` etc.